### PR TITLE
fix: upgrade to actions/cache@v5 (legacy cache service sunset)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ runs:
       otp-version: ${{ inputs.otp-version }}
 
   - name: Restore deps cache
-    uses: hgdata/cache/restore@v3
+    uses: actions/cache/restore@v5
     id: deps-cache
     with:
       path: deps
@@ -68,7 +68,7 @@ runs:
         deps-${{ inputs.cache-key }}-${{ runner.os }}-
 
   - name: Restore build cache
-    uses: hgdata/cache/restore@v3
+    uses: actions/cache/restore@v5
     id: build-cache
     with:
       path: _build
@@ -113,7 +113,7 @@ runs:
     shell: bash
 
   - name: Save deps cache
-    uses: hgdata/cache/save@v3
+    uses: actions/cache/save@v5
     if: steps.deps-cache.outputs.cache-hit != 'true'
     id: deps-cache-save
     with:
@@ -131,7 +131,7 @@ runs:
     if: inputs.build-app == 'true'
 
   - name: Save build cache
-    uses: hgdata/cache/save@v3
+    uses: actions/cache/save@v5
     if: inputs.build-app == 'true' && steps.build-cache.outputs.cache-hit != 'true'
     id: build-cache-save
     with:


### PR DESCRIPTION
## Summary

- Replace `hgdata/cache/restore@v3` and `hgdata/cache/save@v3` with `actions/cache/restore@v5` and `actions/cache/save@v5`

## Problem

The `hgdata/cache` fork is at `v3.3.x`, which uses the **legacy GitHub Actions cache service that was sunset on February 1, 2025**. Every cache save/restore has been silently failing across all repos that use this action:

```
##[warning]Failed to save: <h2>Our services aren't available right now</h2>
```

This means **no Elixir CI job has had working dependency or build caching for over a year**. Every run does a full cold build (~5 min setup instead of ~1 min).

## Root Cause

GitHub deprecated the legacy cache service and requires `actions/cache` v3.4.0+ or v4.2.0+ for the new cache service v2 APIs. The `hgdata/cache` fork only has up to `v4.1.2`, which is also before the cutoff (`v4.2.0` is required). See: https://github.com/actions/cache#readme

## Fix

This PR uses `actions/cache@v5` directly (upstream) since no `hgdata/cache` version has a working backend.

## Follow-up: sync the hgdata/cache fork

The `hgdata/cache` fork should be synced with upstream `actions/cache` so that other repos using `hgdata/cache@v3` or `hgdata/cache@v4` also get the fix. The fork needs to be updated to at least:
- `v3` tag → upstream `v3.4.0`+
- `v4` tag → upstream `v4.2.0`+

Once that's done, this action can switch back from `actions/cache@v5` to `hgdata/cache@v4` (or `@v5` once forked).

## Verification

Tested on [HGData/vulcan PR #2183](https://github.com/HGData/vulcan/pull/2183) — deps cache restores successfully across jobs, build cache saves and restores correctly.